### PR TITLE
Get Window Dimensions Dynamically

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,12 +1,12 @@
 //  @flow
 
 import * as React from 'react';
-import { TouchableOpacity, Modal, View, I18nManager } from 'react-native';
+import { TouchableOpacity, Modal, View, I18nManager, Dimensions } from 'react-native';
 import { ViewPropTypes as RNViewPropTypes } from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 
 import Triangle from './Triangle';
-import { ScreenWidth, ScreenHeight, isIOS } from './helpers';
+import { isIOS } from './helpers';
 import getTooltipCoordinate from './getTooltipCoordinate';
 
 const ViewPropTypes = RNViewPropTypes || View.propTypes;
@@ -89,6 +89,7 @@ class Tooltip extends React.Component<Props, State> {
   };
 
   getTooltipStyle = () => {
+    const {width: ScreenWidth, height: ScreenHeight} = Dimensions.get('window');
     const { yOffset, xOffset, elementHeight, elementWidth } = this.state;
     const {
       height,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,8 +3,6 @@
 import { Platform, Dimensions } from 'react-native';
 
 const Screen = Dimensions.get('window');
-export const ScreenWidth: number = Screen.width;
-export const ScreenHeight: number = Screen.height;
 export const isIOS = Platform.OS === 'ios';
 
 export const Colors = {


### PR DESCRIPTION
**Reason for the change:**
- The positioning of the Tooltip changes depending on whether the app was opened in Portrait or Landscape Mode.

**Why was this happening?**
- Currently the Dimensions are set globally which means that it won't update when the orientation of the device changes.

**Fix**
- By putting `Dimensions.get('window')` inline, it will update everytime the component rerenders.